### PR TITLE
Fix for AI Validation vector store objects

### DIFF
--- a/console/ai_validation.php
+++ b/console/ai_validation.php
@@ -226,12 +226,10 @@ class ai_validation extends Command
             "Content-Type: application/json"
         ]);
 
-		// Extract only file_id strings, skip nulls
+        // Extract only file_id strings, skip nulls
         $file_ids = [];
-        foreach ($uploaded_files as $file_info)
-		{
-            if (!empty($file_info['file_id']))
-			{
+        foreach ($uploaded_files as $file_info) {
+            if (!empty($file_info['file_id'])) {
                 $file_ids[] = $file_info['file_id'];
             }
         }
@@ -271,7 +269,8 @@ class ai_validation extends Command
         $ch = curl_init("https://api.openai.com/v1/assistants");
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
             "Authorization: Bearer " . self::OPENAI_API_KEY,
-            "Content-Type: application/json"
+            "Content-Type: application/json",
+            "OpenAI-Beta: assistants=v2"
         ]);
 
         $body = [
@@ -280,8 +279,7 @@ class ai_validation extends Command
             'model' => 'gpt-4.1',
             'tools' => [
                 ['type' => 'file_search']
-            ],
-            'vector_store_ids' => [$vector_store_id]
+            ]
         ];
 
         curl_setopt($ch, CURLOPT_POST, true);
@@ -312,7 +310,8 @@ class ai_validation extends Command
         $ch = curl_init("https://api.openai.com/v1/threads/runs");
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
             "Authorization: Bearer " . self::OPENAI_API_KEY,
-            "Content-Type: application/json"
+            "Content-Type: application/json",
+            "OpenAI-Beta: assistants=v2"
         ]);
 
         $body = [

--- a/console/ai_validation.php
+++ b/console/ai_validation.php
@@ -226,13 +226,22 @@ class ai_validation extends Command
             "Content-Type: application/json"
         ]);
 
+		// Extract only file_id strings, skip nulls
+        $file_ids = [];
+        foreach ($uploaded_files as $file_info)
+		{
+            if (!empty($file_info['file_id']))
+			{
+                $file_ids[] = $file_info['file_id'];
+            }
+        }
+        // Add manifest file id
+        $file_ids[] = $manifest_id;
+
         $body = [
             'name' => 'phpBB Extension Validation',
-            'file_ids' => array_values($uploaded_files),
+            'file_ids' => $file_ids,
         ];
-
-        // Include manifest
-        $body['file_ids'][] = $manifest_id;
 
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
So I got the AI validator to work, erm, to output a response without erroring after making these changes:

> The root cause is that in `create_vector_store method`, we are passing the entire `$uploaded_files` array (which contains > arrays/objects for each file) as `file_ids`, but the API expects an array of file ID strings.
> 
> You need to extract only the `file_id` values (and skip nulls) before passing them to the API.
>
> This should update the code in `create_vector_store` to build `file_ids` as an array of strings, not objects.

> you must add the header OpenAI-Beta: assistants=v2 to your API request to use the Assistants API.

> The 'vector_store_ids' parameter has been removed from the assistant creation request, as required by the latest OpenAI API.

> The required OpenAI-Beta: assistants=v2 header has now been added to the validation run request as well.
